### PR TITLE
flatpak: Fix screenshot URL

### DIFF
--- a/flatpak/tech.feliciano.pocket-casts.appdata.xml
+++ b/flatpak/tech.feliciano.pocket-casts.appdata.xml
@@ -15,7 +15,7 @@
   </description>
   <screenshots>
     <screenshot type="default">
-      <image type="source">https://github.com/felicianotech/pocket-casts-desktop-app/raw/master/screenshot.png</image>
+      <image type="source">https://raw.githubusercontent.com/felicianotech/pocket-casts-desktop-app/trunk/screenshot.png</image>
     </screenshot>
   </screenshots>
   <content_rating type="oars-1.1" />


### PR DESCRIPTION
The main development branch was renamed, so the URL changed.