### PR TITLE
feat: add rpm artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
       - checkout
       - run:
           name: "Install Dependancies"
-          command: sudo apt-get update && sudo apt-get install --yes dpkg fakeroot
+          command: sudo apt-get update && sudo apt-get install --yes dpkg fakeroot rpm
       - node/install-packages
       - run:
           name: "Build"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
 			"devDependencies": {
 				"@electron-forge/cli": "^6.0.1",
 				"@electron-forge/maker-deb": "^6.0.1",
+				"@electron-forge/maker-rpm": "^6.1.1",
 				"@electron-forge/maker-zip": "^6.0.0-beta.63",
 				"electron": "^21.2.3"
 			}
@@ -1617,6 +1618,349 @@
 			}
 		},
 		"node_modules/@electron-forge/maker-deb/node_modules/yargs-parser": {
+			"version": "21.1.1",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@electron-forge/maker-rpm": {
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/@electron-forge/maker-rpm/-/maker-rpm-6.1.1.tgz",
+			"integrity": "sha512-ya+XtNqHuYENQh4+0XLVM5MYQYR/Y3gKxfUO/V7top6R+TWQwgcUywGEcofxjKVB7fIbDVu4yYgqMujvF6m4QQ==",
+			"dev": true,
+			"dependencies": {
+				"@electron-forge/maker-base": "6.1.1",
+				"@electron-forge/shared-types": "6.1.1"
+			},
+			"engines": {
+				"node": ">= 14.17.5"
+			},
+			"optionalDependencies": {
+				"electron-installer-redhat": "^3.2.0"
+			}
+		},
+		"node_modules/@electron-forge/maker-rpm/node_modules/@electron-forge/maker-base": {
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/@electron-forge/maker-base/-/maker-base-6.1.1.tgz",
+			"integrity": "sha512-qEW8vuSq6/r1rKh7JENK9yGmueymMzbm817GDk5usHia5o7otHYY4JMkdzZaKww56Ed/Ege2ch6LEYqYGTfl/Q==",
+			"dev": true,
+			"dependencies": {
+				"@electron-forge/shared-types": "6.1.1",
+				"fs-extra": "^10.0.0",
+				"which": "^2.0.2"
+			},
+			"engines": {
+				"node": ">= 14.17.5"
+			}
+		},
+		"node_modules/@electron-forge/maker-rpm/node_modules/@electron-forge/shared-types": {
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-6.1.1.tgz",
+			"integrity": "sha512-sFQQ2ldMq5mlNv4m7lZOZLf9aOn6MLNc8QVeTzOBQ+psxI3mVTDjb+/Lhs/jU8dm2igVfEqAmlj57Gi+C4u4Vw==",
+			"dev": true,
+			"dependencies": {
+				"@electron/rebuild": "^3.2.10",
+				"electron-packager": "^17.1.1",
+				"listr2": "^5.0.3"
+			},
+			"engines": {
+				"node": ">= 14.17.5"
+			}
+		},
+		"node_modules/@electron-forge/maker-rpm/node_modules/@electron/get": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.2.tgz",
+			"integrity": "sha512-eFZVFoRXb3GFGd7Ak7W4+6jBl9wBtiZ4AaYOse97ej6mKj5tkyO0dUnUChs1IhJZtx1BENo4/p4WUTXpi6vT+g==",
+			"dev": true,
+			"dependencies": {
+				"debug": "^4.1.1",
+				"env-paths": "^2.2.0",
+				"fs-extra": "^8.1.0",
+				"got": "^11.8.5",
+				"progress": "^2.0.3",
+				"semver": "^6.2.0",
+				"sumchecker": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"optionalDependencies": {
+				"global-agent": "^3.0.0"
+			}
+		},
+		"node_modules/@electron-forge/maker-rpm/node_modules/@electron/get/node_modules/fs-extra": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+			"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+			"dev": true,
+			"dependencies": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^4.0.0",
+				"universalify": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=6 <7 || >=8"
+			}
+		},
+		"node_modules/@electron-forge/maker-rpm/node_modules/@electron/get/node_modules/semver": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+			"dev": true,
+			"bin": {
+				"semver": "bin/semver.js"
+			}
+		},
+		"node_modules/@electron-forge/maker-rpm/node_modules/@sindresorhus/is": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+			"integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/is?sponsor=1"
+			}
+		},
+		"node_modules/@electron-forge/maker-rpm/node_modules/@szmarczak/http-timer": {
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+			"integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+			"dev": true,
+			"dependencies": {
+				"defer-to-connect": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@electron-forge/maker-rpm/node_modules/cacheable-request": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.2.tgz",
+			"integrity": "sha512-pouW8/FmiPQbuGpkXQ9BAPv/Mo5xDGANgSNXzTzJ8DrKGuXOssM4wIQRjfanNRh3Yu5cfYPvcorqbhg2KIJtew==",
+			"dev": true,
+			"dependencies": {
+				"clone-response": "^1.0.2",
+				"get-stream": "^5.1.0",
+				"http-cache-semantics": "^4.0.0",
+				"keyv": "^4.0.0",
+				"lowercase-keys": "^2.0.0",
+				"normalize-url": "^6.0.1",
+				"responselike": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@electron-forge/maker-rpm/node_modules/decompress-response": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+			"integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+			"dev": true,
+			"dependencies": {
+				"mimic-response": "^3.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@electron-forge/maker-rpm/node_modules/defer-to-connect": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+			"integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@electron-forge/maker-rpm/node_modules/electron-packager": {
+			"version": "17.1.1",
+			"resolved": "https://registry.npmjs.org/electron-packager/-/electron-packager-17.1.1.tgz",
+			"integrity": "sha512-r1NDtlajsq7gf2EXgjRfblCVPquvD2yeg+6XGErOKblvxOpDi0iulZLVhgYDP4AEF1P5/HgbX/vwjlkEv7PEIQ==",
+			"dev": true,
+			"dependencies": {
+				"@electron/asar": "^3.2.1",
+				"@electron/get": "^2.0.0",
+				"@electron/notarize": "^1.2.3",
+				"@electron/osx-sign": "^1.0.1",
+				"@electron/universal": "^1.3.2",
+				"cross-spawn-windows-exe": "^1.2.0",
+				"debug": "^4.0.1",
+				"extract-zip": "^2.0.0",
+				"filenamify": "^4.1.0",
+				"fs-extra": "^10.1.0",
+				"galactus": "^0.2.1",
+				"get-package-info": "^1.0.0",
+				"junk": "^3.1.0",
+				"parse-author": "^2.0.0",
+				"plist": "^3.0.0",
+				"rcedit": "^3.0.1",
+				"resolve": "^1.1.6",
+				"semver": "^7.1.3",
+				"yargs-parser": "^21.1.1"
+			},
+			"bin": {
+				"electron-packager": "bin/electron-packager.js"
+			},
+			"engines": {
+				"node": ">= 14.17.5"
+			},
+			"funding": {
+				"url": "https://github.com/electron/electron-packager?sponsor=1"
+			}
+		},
+		"node_modules/@electron-forge/maker-rpm/node_modules/fs-extra": {
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+			"integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+			"dev": true,
+			"dependencies": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@electron-forge/maker-rpm/node_modules/fs-extra/node_modules/jsonfile": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+			"integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+			"dev": true,
+			"dependencies": {
+				"universalify": "^2.0.0"
+			},
+			"optionalDependencies": {
+				"graceful-fs": "^4.1.6"
+			}
+		},
+		"node_modules/@electron-forge/maker-rpm/node_modules/fs-extra/node_modules/universalify": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+			"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+			"dev": true,
+			"engines": {
+				"node": ">= 10.0.0"
+			}
+		},
+		"node_modules/@electron-forge/maker-rpm/node_modules/get-stream": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+			"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+			"dev": true,
+			"dependencies": {
+				"pump": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@electron-forge/maker-rpm/node_modules/got": {
+			"version": "11.8.6",
+			"resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
+			"integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
+			"dev": true,
+			"dependencies": {
+				"@sindresorhus/is": "^4.0.0",
+				"@szmarczak/http-timer": "^4.0.5",
+				"@types/cacheable-request": "^6.0.1",
+				"@types/responselike": "^1.0.0",
+				"cacheable-lookup": "^5.0.3",
+				"cacheable-request": "^7.0.2",
+				"decompress-response": "^6.0.0",
+				"http2-wrapper": "^1.0.0-beta.5.2",
+				"lowercase-keys": "^2.0.0",
+				"p-cancelable": "^2.0.0",
+				"responselike": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10.19.0"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/got?sponsor=1"
+			}
+		},
+		"node_modules/@electron-forge/maker-rpm/node_modules/json-buffer": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+			"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+			"dev": true
+		},
+		"node_modules/@electron-forge/maker-rpm/node_modules/keyv": {
+			"version": "4.5.2",
+			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.2.tgz",
+			"integrity": "sha512-5MHbFaKn8cNSmVW7BYnijeAVlE4cYA/SVkifVgrh7yotnfhKmjuXpDKjrABLnT0SfHWV21P8ow07OGfRrNDg8g==",
+			"dev": true,
+			"dependencies": {
+				"json-buffer": "3.0.1"
+			}
+		},
+		"node_modules/@electron-forge/maker-rpm/node_modules/lowercase-keys": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+			"integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@electron-forge/maker-rpm/node_modules/mimic-response": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+			"integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@electron-forge/maker-rpm/node_modules/normalize-url": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+			"integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@electron-forge/maker-rpm/node_modules/p-cancelable": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+			"integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@electron-forge/maker-rpm/node_modules/responselike": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
+			"integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
+			"dev": true,
+			"dependencies": {
+				"lowercase-keys": "^2.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@electron-forge/maker-rpm/node_modules/yargs-parser": {
 			"version": "21.1.1",
 			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
 			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
@@ -5363,6 +5707,163 @@
 			"optional": true,
 			"engines": {
 				"node": ">= 10.0.0"
+			}
+		},
+		"node_modules/electron-installer-redhat": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/electron-installer-redhat/-/electron-installer-redhat-3.4.0.tgz",
+			"integrity": "sha512-gEISr3U32Sgtj+fjxUAlSDo3wyGGq6OBx7rF5UdpIgbnpUvMN4W5uYb0ThpnAZ42VEJh/3aODQXHbFS4f5J3Iw==",
+			"dev": true,
+			"optional": true,
+			"os": [
+				"darwin",
+				"linux"
+			],
+			"dependencies": {
+				"@malept/cross-spawn-promise": "^1.0.0",
+				"debug": "^4.1.1",
+				"electron-installer-common": "^0.10.2",
+				"fs-extra": "^9.0.0",
+				"lodash": "^4.17.15",
+				"word-wrap": "^1.2.3",
+				"yargs": "^16.0.2"
+			},
+			"bin": {
+				"electron-installer-redhat": "src/cli.js"
+			},
+			"engines": {
+				"node": ">= 10.0.0"
+			}
+		},
+		"node_modules/electron-installer-redhat/node_modules/@malept/cross-spawn-promise": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-1.1.1.tgz",
+			"integrity": "sha512-RTBGWL5FWQcg9orDOCcp4LvItNzUPcyEU9bwaeJX0rJ1IQxzucC48Y0/sQLp/g6t99IQgAlGIaesJS+gTn7tVQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://github.com/sponsors/malept"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/subscription/pkg/npm-.malept-cross-spawn-promise?utm_medium=referral&utm_source=npm_fund"
+				}
+			],
+			"optional": true,
+			"dependencies": {
+				"cross-spawn": "^7.0.1"
+			},
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/electron-installer-redhat/node_modules/cliui": {
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+			"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+			"dev": true,
+			"optional": true,
+			"dependencies": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.0",
+				"wrap-ansi": "^7.0.0"
+			}
+		},
+		"node_modules/electron-installer-redhat/node_modules/fs-extra": {
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+			"integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+			"dev": true,
+			"optional": true,
+			"dependencies": {
+				"at-least-node": "^1.0.0",
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/electron-installer-redhat/node_modules/jsonfile": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+			"integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+			"dev": true,
+			"optional": true,
+			"dependencies": {
+				"universalify": "^2.0.0"
+			},
+			"optionalDependencies": {
+				"graceful-fs": "^4.1.6"
+			}
+		},
+		"node_modules/electron-installer-redhat/node_modules/universalify": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+			"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+			"dev": true,
+			"optional": true,
+			"engines": {
+				"node": ">= 10.0.0"
+			}
+		},
+		"node_modules/electron-installer-redhat/node_modules/wrap-ansi": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"dev": true,
+			"optional": true,
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/electron-installer-redhat/node_modules/y18n": {
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+			"dev": true,
+			"optional": true,
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/electron-installer-redhat/node_modules/yargs": {
+			"version": "16.2.0",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+			"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+			"dev": true,
+			"optional": true,
+			"dependencies": {
+				"cliui": "^7.0.2",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"require-directory": "^2.1.1",
+				"string-width": "^4.2.0",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^20.2.2"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/electron-installer-redhat/node_modules/yargs-parser": {
+			"version": "20.2.9",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+			"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+			"dev": true,
+			"optional": true,
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/electron-notarize": {
@@ -10139,6 +10640,259 @@
 				}
 			}
 		},
+		"@electron-forge/maker-rpm": {
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/@electron-forge/maker-rpm/-/maker-rpm-6.1.1.tgz",
+			"integrity": "sha512-ya+XtNqHuYENQh4+0XLVM5MYQYR/Y3gKxfUO/V7top6R+TWQwgcUywGEcofxjKVB7fIbDVu4yYgqMujvF6m4QQ==",
+			"dev": true,
+			"requires": {
+				"@electron-forge/maker-base": "6.1.1",
+				"@electron-forge/shared-types": "6.1.1",
+				"electron-installer-redhat": "^3.2.0"
+			},
+			"dependencies": {
+				"@electron-forge/maker-base": {
+					"version": "6.1.1",
+					"resolved": "https://registry.npmjs.org/@electron-forge/maker-base/-/maker-base-6.1.1.tgz",
+					"integrity": "sha512-qEW8vuSq6/r1rKh7JENK9yGmueymMzbm817GDk5usHia5o7otHYY4JMkdzZaKww56Ed/Ege2ch6LEYqYGTfl/Q==",
+					"dev": true,
+					"requires": {
+						"@electron-forge/shared-types": "6.1.1",
+						"fs-extra": "^10.0.0",
+						"which": "^2.0.2"
+					}
+				},
+				"@electron-forge/shared-types": {
+					"version": "6.1.1",
+					"resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-6.1.1.tgz",
+					"integrity": "sha512-sFQQ2ldMq5mlNv4m7lZOZLf9aOn6MLNc8QVeTzOBQ+psxI3mVTDjb+/Lhs/jU8dm2igVfEqAmlj57Gi+C4u4Vw==",
+					"dev": true,
+					"requires": {
+						"@electron/rebuild": "^3.2.10",
+						"electron-packager": "^17.1.1",
+						"listr2": "^5.0.3"
+					}
+				},
+				"@electron/get": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.2.tgz",
+					"integrity": "sha512-eFZVFoRXb3GFGd7Ak7W4+6jBl9wBtiZ4AaYOse97ej6mKj5tkyO0dUnUChs1IhJZtx1BENo4/p4WUTXpi6vT+g==",
+					"dev": true,
+					"requires": {
+						"debug": "^4.1.1",
+						"env-paths": "^2.2.0",
+						"fs-extra": "^8.1.0",
+						"global-agent": "^3.0.0",
+						"got": "^11.8.5",
+						"progress": "^2.0.3",
+						"semver": "^6.2.0",
+						"sumchecker": "^3.0.1"
+					},
+					"dependencies": {
+						"fs-extra": {
+							"version": "8.1.0",
+							"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+							"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+							"dev": true,
+							"requires": {
+								"graceful-fs": "^4.2.0",
+								"jsonfile": "^4.0.0",
+								"universalify": "^0.1.0"
+							}
+						},
+						"semver": {
+							"version": "6.3.0",
+							"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+							"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+							"dev": true
+						}
+					}
+				},
+				"@sindresorhus/is": {
+					"version": "4.6.0",
+					"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+					"integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+					"dev": true
+				},
+				"@szmarczak/http-timer": {
+					"version": "4.0.6",
+					"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+					"integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+					"dev": true,
+					"requires": {
+						"defer-to-connect": "^2.0.0"
+					}
+				},
+				"cacheable-request": {
+					"version": "7.0.2",
+					"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.2.tgz",
+					"integrity": "sha512-pouW8/FmiPQbuGpkXQ9BAPv/Mo5xDGANgSNXzTzJ8DrKGuXOssM4wIQRjfanNRh3Yu5cfYPvcorqbhg2KIJtew==",
+					"dev": true,
+					"requires": {
+						"clone-response": "^1.0.2",
+						"get-stream": "^5.1.0",
+						"http-cache-semantics": "^4.0.0",
+						"keyv": "^4.0.0",
+						"lowercase-keys": "^2.0.0",
+						"normalize-url": "^6.0.1",
+						"responselike": "^2.0.0"
+					}
+				},
+				"decompress-response": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+					"integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+					"dev": true,
+					"requires": {
+						"mimic-response": "^3.1.0"
+					}
+				},
+				"defer-to-connect": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+					"integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+					"dev": true
+				},
+				"electron-packager": {
+					"version": "17.1.1",
+					"resolved": "https://registry.npmjs.org/electron-packager/-/electron-packager-17.1.1.tgz",
+					"integrity": "sha512-r1NDtlajsq7gf2EXgjRfblCVPquvD2yeg+6XGErOKblvxOpDi0iulZLVhgYDP4AEF1P5/HgbX/vwjlkEv7PEIQ==",
+					"dev": true,
+					"requires": {
+						"@electron/asar": "^3.2.1",
+						"@electron/get": "^2.0.0",
+						"@electron/notarize": "^1.2.3",
+						"@electron/osx-sign": "^1.0.1",
+						"@electron/universal": "^1.3.2",
+						"cross-spawn-windows-exe": "^1.2.0",
+						"debug": "^4.0.1",
+						"extract-zip": "^2.0.0",
+						"filenamify": "^4.1.0",
+						"fs-extra": "^10.1.0",
+						"galactus": "^0.2.1",
+						"get-package-info": "^1.0.0",
+						"junk": "^3.1.0",
+						"parse-author": "^2.0.0",
+						"plist": "^3.0.0",
+						"rcedit": "^3.0.1",
+						"resolve": "^1.1.6",
+						"semver": "^7.1.3",
+						"yargs-parser": "^21.1.1"
+					}
+				},
+				"fs-extra": {
+					"version": "10.1.0",
+					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+					"integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.2.0",
+						"jsonfile": "^6.0.1",
+						"universalify": "^2.0.0"
+					},
+					"dependencies": {
+						"jsonfile": {
+							"version": "6.1.0",
+							"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+							"integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+							"dev": true,
+							"requires": {
+								"graceful-fs": "^4.1.6",
+								"universalify": "^2.0.0"
+							}
+						},
+						"universalify": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+							"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+							"dev": true
+						}
+					}
+				},
+				"get-stream": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+					"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+					"dev": true,
+					"requires": {
+						"pump": "^3.0.0"
+					}
+				},
+				"got": {
+					"version": "11.8.6",
+					"resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
+					"integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
+					"dev": true,
+					"requires": {
+						"@sindresorhus/is": "^4.0.0",
+						"@szmarczak/http-timer": "^4.0.5",
+						"@types/cacheable-request": "^6.0.1",
+						"@types/responselike": "^1.0.0",
+						"cacheable-lookup": "^5.0.3",
+						"cacheable-request": "^7.0.2",
+						"decompress-response": "^6.0.0",
+						"http2-wrapper": "^1.0.0-beta.5.2",
+						"lowercase-keys": "^2.0.0",
+						"p-cancelable": "^2.0.0",
+						"responselike": "^2.0.0"
+					}
+				},
+				"json-buffer": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+					"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+					"dev": true
+				},
+				"keyv": {
+					"version": "4.5.2",
+					"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.2.tgz",
+					"integrity": "sha512-5MHbFaKn8cNSmVW7BYnijeAVlE4cYA/SVkifVgrh7yotnfhKmjuXpDKjrABLnT0SfHWV21P8ow07OGfRrNDg8g==",
+					"dev": true,
+					"requires": {
+						"json-buffer": "3.0.1"
+					}
+				},
+				"lowercase-keys": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+					"integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+					"dev": true
+				},
+				"mimic-response": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+					"integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+					"dev": true
+				},
+				"normalize-url": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+					"integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+					"dev": true
+				},
+				"p-cancelable": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+					"integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+					"dev": true
+				},
+				"responselike": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
+					"integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
+					"dev": true,
+					"requires": {
+						"lowercase-keys": "^2.0.0"
+					}
+				},
+				"yargs-parser": {
+					"version": "21.1.1",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+					"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+					"dev": true
+				}
+			}
+		},
 		"@electron-forge/maker-zip": {
 			"version": "6.0.0-beta.63",
 			"resolved": "https://registry.npmjs.org/@electron-forge/maker-zip/-/maker-zip-6.0.0-beta.63.tgz",
@@ -12913,6 +13667,119 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
 					"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+					"dev": true,
+					"optional": true
+				}
+			}
+		},
+		"electron-installer-redhat": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/electron-installer-redhat/-/electron-installer-redhat-3.4.0.tgz",
+			"integrity": "sha512-gEISr3U32Sgtj+fjxUAlSDo3wyGGq6OBx7rF5UdpIgbnpUvMN4W5uYb0ThpnAZ42VEJh/3aODQXHbFS4f5J3Iw==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"@malept/cross-spawn-promise": "^1.0.0",
+				"debug": "^4.1.1",
+				"electron-installer-common": "^0.10.2",
+				"fs-extra": "^9.0.0",
+				"lodash": "^4.17.15",
+				"word-wrap": "^1.2.3",
+				"yargs": "^16.0.2"
+			},
+			"dependencies": {
+				"@malept/cross-spawn-promise": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-1.1.1.tgz",
+					"integrity": "sha512-RTBGWL5FWQcg9orDOCcp4LvItNzUPcyEU9bwaeJX0rJ1IQxzucC48Y0/sQLp/g6t99IQgAlGIaesJS+gTn7tVQ==",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"cross-spawn": "^7.0.1"
+					}
+				},
+				"cliui": {
+					"version": "7.0.4",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+					"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"string-width": "^4.2.0",
+						"strip-ansi": "^6.0.0",
+						"wrap-ansi": "^7.0.0"
+					}
+				},
+				"fs-extra": {
+					"version": "9.1.0",
+					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+					"integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"at-least-node": "^1.0.0",
+						"graceful-fs": "^4.2.0",
+						"jsonfile": "^6.0.1",
+						"universalify": "^2.0.0"
+					}
+				},
+				"jsonfile": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+					"integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"graceful-fs": "^4.1.6",
+						"universalify": "^2.0.0"
+					}
+				},
+				"universalify": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+					"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+					"dev": true,
+					"optional": true
+				},
+				"wrap-ansi": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+					"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"ansi-styles": "^4.0.0",
+						"string-width": "^4.1.0",
+						"strip-ansi": "^6.0.0"
+					}
+				},
+				"y18n": {
+					"version": "5.0.8",
+					"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+					"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+					"dev": true,
+					"optional": true
+				},
+				"yargs": {
+					"version": "16.2.0",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+					"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"cliui": "^7.0.2",
+						"escalade": "^3.1.1",
+						"get-caller-file": "^2.0.5",
+						"require-directory": "^2.1.1",
+						"string-width": "^4.2.0",
+						"y18n": "^5.0.5",
+						"yargs-parser": "^20.2.2"
+					}
+				},
+				"yargs-parser": {
+					"version": "20.2.9",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+					"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
 					"dev": true,
 					"optional": true
 				}

--- a/package.json
+++ b/package.json
@@ -51,6 +51,11 @@
 				"Icon": "/usr/share/icons/hicolor/0x0/apps/pocket-casts.png"
 			}
 		},
+		"rpm": {
+			"desktop": {
+				"Icon": "/usr/share/icons/hicolor/0x0/apps/pocket-casts.png"
+			}
+		},
 		"extraResources": [
 			{
 				"from": "tray-icon.png",
@@ -61,6 +66,7 @@
 	"devDependencies": {
 		"@electron-forge/cli": "^6.0.1",
 		"@electron-forge/maker-deb": "^6.0.1",
+		"@electron-forge/maker-rpm": "^6.1.1",
 		"@electron-forge/maker-zip": "^6.0.0-beta.63",
 		"electron": "^21.2.3"
 	},
@@ -76,6 +82,10 @@
 				},
 				{
 					"name": "@electron-forge/maker-deb",
+					"config": {}
+				},
+				{
+					"name": "@electron-forge/maker-rpm",
 					"config": {}
 				}
 			]


### PR DESCRIPTION
Adds RPM artifacts to build

CircleCI on my fork generated the artifacts https://app.circleci.com/pipelines/github/altanunsal/pocket-casts-desktop-app/4/workflows/55f88095-c99a-45ff-b8b1-77c233e42b56

## Key changes
- Add `@electron-forge/maker-rpm` as a dev dependency
- Update the ci config to include the `rpm` package in the docker image so `rpmbuild`  cli is available for electron-forge
- Add some additional config

## TODO
Consider creating a rpm repository via COPR: https://docs.fedoraproject.org/en-US/quick-docs/publish-rpm-on-copr/